### PR TITLE
Fix deprecation warnings on 0.6

### DIFF
--- a/src/jump.jl
+++ b/src/jump.jl
@@ -522,7 +522,7 @@ function piecewiselinear(m::JuMP.Model, x₁::JuMP.Variable, x₂::JuMP.Variable
     ˣtoⁱ = Dict(uˣ[i] => i for i in 1:nˣ)
     ʸtoʲ = Dict(uʸ[i] => i for i in 1:nʸ)
 
-    fd = Array(Float64, nˣ, nʸ)
+    fd = Array{Float64}(nˣ, nʸ)
     for (v,fv) in zip(pwl.x, pwl.z)
         # i is the linear index into pwl.x...really want (i,j) pair
         fd[ˣtoⁱ[v[1]],ʸtoʲ[v[2]]] = fv

--- a/src/types.jl
+++ b/src/types.jl
@@ -14,7 +14,7 @@ end
 
 PWLFunction(x, z, T) = PWLFunction(x, z, T, Dict())
 
-typealias UnivariatePWLFunction PWLFunction{1}
+const UnivariatePWLFunction = PWLFunction{1}
 
 function UnivariatePWLFunction(x, z)
     @assert issorted(x)
@@ -26,7 +26,7 @@ function UnivariatePWLFunction(x, fz::Function)
     PWLFunction(Tuple{Float64}[(xx,) for xx in x], map(t->convert(Float64,fz(t)), x), [[i,i+1] for i in 1:length(x)-1])
 end
 
-typealias  BivariatePWLFunction PWLFunction{2}
+const BivariatePWLFunction = PWLFunction{2}
 
 function BivariatePWLFunction(x, y, fz::Function; pattern=:BestFit, seed=hash((length(x),length(y))))
     @assert issorted(x)


### PR DESCRIPTION
Note that the new syntax is also valid on 0.5 (`const` instead of `typealias` was already possible in 0,5 when there were no free type parameters), so Compat is not necessary.